### PR TITLE
feat: rework table and column inclusion to be an allow-list

### DIFF
--- a/src/relations.ts
+++ b/src/relations.ts
@@ -278,7 +278,7 @@ type DrizzleToZeroSchema<
           ZeroTableBuilderSchema<
             K & string,
             TDrizzleSchema[K],
-            TColumnConfig[K],
+            NonNullable<TColumnConfig[K]>,
             TCasing
           >
         >
@@ -496,11 +496,17 @@ const drizzleZeroConfig = <
 
       const tableConfig = config?.tables?.[tableName as keyof TColumnConfig];
 
-      // skip tables that don't have a config
-      if (tableConfig === false) {
+      if (
+        config?.tables !== undefined &&
+        (tableConfig === false || tableConfig === undefined)
+      ) {
         debugLog(
           config?.debug,
-          `Skipping table ${String(tableName)} - no config provided`,
+          `Skipping table ${String(tableName)} - ${
+            tableConfig === false
+              ? "explicitly excluded"
+              : "not mentioned in config"
+          }`,
         );
         continue;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,16 +14,18 @@ export type ColumnIndexKeys<TTable extends Table> = {
  * @template TDrizzleSchema - The complete Drizzle schema
  */
 export type TableColumnsConfig<TDrizzleSchema extends Record<string, unknown>> =
-  Flatten<{
-    /**
-     * The columns to include in the Zero schema.
-     */
-    readonly [K in keyof TDrizzleSchema as TDrizzleSchema[K] extends Table<any>
-      ? K
-      : never]: TDrizzleSchema[K] extends Table<any>
-      ? ColumnsConfig<TDrizzleSchema[K]>
-      : never;
-  }>;
+  Partial<
+    Flatten<{
+      /**
+       * The columns to include in the Zero schema.
+       */
+      readonly [K in keyof TDrizzleSchema as TDrizzleSchema[K] extends Table<any>
+        ? K
+        : never]: TDrizzleSchema[K] extends Table<any>
+        ? ColumnsConfig<TDrizzleSchema[K]>
+        : never;
+    }>
+  >;
 
 /**
  * A default config type which includes all tables in the Drizzle schema.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -64,12 +64,11 @@ describe("drizzleZeroConfig with explicit table and column configuration", () =>
   test("should handle explicit table and column configurations", () => {
     const schema = drizzleZeroConfig(drizzleSchema, {
       tables: {
-        users: {
-          name: true,
-          email: false,
-          // phone is not mentioned, should be excluded
+        users: true, // include all columns
+        usersToPosts: {
+          userId: false, // will be included anyway because it is part of the primary key
+          // role is not mentioned, should be excluded
         },
-        usersToPosts: true, // include all columns
         posts: false,
         // comments table is not mentioned, should be excluded
       },
@@ -88,11 +87,11 @@ describe("drizzleZeroConfig with explicit table and column configuration", () =>
     // `users` table should have `id` (pk) and `name`
     expect(
       new Set(Object.keys((schema.tables as any).users.columns)),
-    ).toStrictEqual(new Set(["id", "name"]));
+    ).toStrictEqual(new Set(["id", "name", "email", "phone"]));
 
     // `usersToPosts` table should have all its columns
     expect(
       new Set(Object.keys((schema.tables as any).usersToPosts.columns)),
-    ).toStrictEqual(new Set(["userId", "postId", "role"]));
+    ).toStrictEqual(new Set(["userId", "postId"]));
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+import { drizzleZeroConfig } from "../src/relations";
+import { pgTable, serial, text, primaryKey } from "drizzle-orm/pg-core";
+
+describe("drizzleZeroConfig with explicit table and column configuration", () => {
+  const users = pgTable("users", {
+    id: serial("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull(),
+    phone: text("phone"),
+  });
+
+  const posts = pgTable("posts", {
+    id: serial("id").primaryKey(),
+    title: text("title").notNull(),
+    content: text("content"),
+    userId: serial("user_id").references(() => users.id),
+  });
+
+  const comments = pgTable("comments", {
+    id: serial("id").primaryKey(),
+    content: text("content").notNull(),
+    postId: serial("post_id").references(() => posts.id),
+  });
+
+  const usersToPosts = pgTable(
+    "users_to_posts",
+    {
+      userId: serial("user_id").references(() => users.id),
+      postId: serial("post_id").references(() => posts.id),
+      role: text("role", { enum: ["owner", "editor"] }),
+    },
+    (t: any) => ({
+      pk: primaryKey({ columns: [t.userId, t.postId] }),
+    }),
+  );
+
+  const drizzleSchema = { users, posts, comments, usersToPosts };
+
+  test("should include all tables and columns when no config is provided", () => {
+    const schema = drizzleZeroConfig(drizzleSchema);
+
+    // All tables should be present
+    expect(Object.keys(schema.tables).length).toBe(4);
+    expect(new Set(Object.keys(schema.tables))).toStrictEqual(
+      new Set(["users", "posts", "comments", "usersToPosts"]),
+    );
+
+    // All columns should be present
+    expect(
+      new Set(Object.keys((schema.tables as any).users.columns)),
+    ).toStrictEqual(new Set(["id", "name", "email", "phone"]));
+    expect(
+      new Set(Object.keys((schema.tables as any).posts.columns)),
+    ).toStrictEqual(new Set(["id", "title", "content", "userId"]));
+    expect(
+      new Set(Object.keys((schema.tables as any).comments.columns)),
+    ).toStrictEqual(new Set(["id", "content", "postId"]));
+    expect(
+      new Set(Object.keys((schema.tables as any).usersToPosts.columns)),
+    ).toStrictEqual(new Set(["userId", "postId", "role"]));
+  });
+
+  test("should handle explicit table and column configurations", () => {
+    const schema = drizzleZeroConfig(drizzleSchema, {
+      tables: {
+        users: {
+          name: true,
+          email: false,
+          // phone is not mentioned, should be excluded
+        },
+        usersToPosts: true, // include all columns
+        posts: false,
+        // comments table is not mentioned, should be excluded
+      },
+    });
+
+    // `users` and `usersToPosts` should be in the schema
+    expect(Object.keys(schema.tables).length).toBe(2);
+    expect(new Set(Object.keys(schema.tables))).toStrictEqual(
+      new Set(["users", "usersToPosts"]),
+    );
+
+    // `posts` and `comments` should be excluded
+    expect((schema.tables as any).posts).toBe(undefined);
+    expect((schema.tables as any).comments).toBe(undefined);
+
+    // `users` table should have `id` (pk) and `name`
+    expect(
+      new Set(Object.keys((schema.tables as any).users.columns)),
+    ).toStrictEqual(new Set(["id", "name"]));
+
+    // `usersToPosts` table should have all its columns
+    expect(
+      new Set(Object.keys((schema.tables as any).usersToPosts.columns)),
+    ).toStrictEqual(new Set(["userId", "postId", "role"]));
+  });
+});


### PR DESCRIPTION
I have a pretty big Drizzle Schema, and multiple apps using different parts of it. Instead of having to explicitly list all tables and columns and explicitly specifying which ones would be included or excluded, I thought it would be simpler to change how drizzle-zero works as it could benefit others as well. Hope you agree with this change.

If this PR gets merged, the behavior will be:
- If the config is not specified (i.e. using `drizzleZeroConfig(schema)`): All tables and columns are included
- If the config is specified:
  - Tables that are not mentioned in the config and those set to `false` will *not* be included
  - Tables set to `true` are included and all of their columns are automatically added
  - Tables with a config value will be included
    - Primary key columns are always included, even if they are set to `false`
    - All other columns must be explicitly set to `true` to be included. Columns not mentioned or set to `false` are excluded